### PR TITLE
Bugfix/container env vars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,24 +59,7 @@ resource "aws_ecs_task_definition" "app_task" {
       retries     = 3
       startPeriod = 20
     }
-    environment = [
-      {
-        name  = "DB_ADDRESS"
-        value = var.domain_address
-      },
-      {
-        name  = "DB_FQDN"
-        value = var.domain_fqdn
-      },
-      {
-        name  = "DB_USERNAME"
-        value = var.domain_username
-      },
-      {
-        name  = "DB_PASSWORD"
-        value = var.domain_password
-      }
-    ]    
+    environment = local.final_environment_vars
   }])
 
   tags = {

--- a/variables.tf
+++ b/variables.tf
@@ -37,24 +37,12 @@ variable "health_check_application" {
   description = "Health check endpoint for the application"
 }
 
-#DB Data
-variable "domain_address" {
-  type = string
-  description = "Domain Address"
-}
-
-variable "domain_fqdn" {
-  type = string
-  description = "Domain FQDN"
-}
-
-variable "domain_username" {
-  type = string
-  description = "Domain Username"
-}
-
-variable "domain_password" {
-  type = string
-  description = "Domain Password"
-  sensitive = true
+#Environment data for the container
+variable "environment_variables" {
+  type = list(object({
+    name = string,
+    value = string
+  }))
+  default = []
+  description = "Environment variables for the container"
 }


### PR DESCRIPTION
### Suggested changes

Removed hardcoded env vars from this resources. Now should be sent as a variable from the callee:

    ```
    export TF_VAR_environment_variables='[
      {"name":"HTTP_LISTENING_PORT","value":"80"},
      {"name":"MONGO_CONNECTION_STRING","value":"mongodb+srv://"}
    ]'
    ```